### PR TITLE
ensure consistent post logout screens

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,8 +45,16 @@ app.get("/login", (req, res) => {
   const base = process.env.BASE_URL!;
   const returnTo =
     (req.query.returnTo as string) ?? "https://app.lodgelink.com";
+  const prompt = (req.query.prompt as string) ?? "login";
+  
   const loginUrl = new URL("/.auth/login/aad", base);
   loginUrl.searchParams.set("post_login_redirect_uri", returnTo);
+  
+  // Add prompt parameter if provided (e.g., prompt=login to force fresh auth)
+  if (prompt) {
+    loginUrl.searchParams.set("prompt", prompt);
+  }
+  
   res.redirect(loginUrl.toString());
 });
 
@@ -55,8 +63,10 @@ app.get("/logout", (req, res) => {
   const base = process.env.BASE_URL!;
   const returnTo =
     (req.query.returnTo as string) ?? "https://app.lodgelink.com";
+  
+  // Use logout endpoint but redirect to login with prompt=login to ensure consistent behavior
   const logoutUrl = new URL("/.auth/logout", base);
-  logoutUrl.searchParams.set("post_logout_redirect_uri", "/login");
+  logoutUrl.searchParams.set("post_logout_redirect_uri", `${base}/login?returnTo=${encodeURIComponent(returnTo)}&prompt=login`);
   res.redirect(logoutUrl.toString());
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,10 +50,8 @@ app.get("/login", (req, res) => {
   const loginUrl = new URL("/.auth/login/aad", base);
   loginUrl.searchParams.set("post_login_redirect_uri", returnTo);
   
-  // Add prompt parameter if provided (e.g., prompt=login to force fresh auth)
-  if (prompt) {
-    loginUrl.searchParams.set("prompt", prompt);
-  }
+  // Always set prompt parameter (e.g., prompt=login to force fresh auth)
+  loginUrl.searchParams.set("prompt", prompt);
   
   res.redirect(loginUrl.toString());
 });


### PR DESCRIPTION
This pull request updates the authentication flow in `src/server.ts` to provide more control over user login and logout behavior. The main changes involve supporting a `prompt` parameter to force re-authentication and ensuring that logging out always redirects users to a fresh login screen.

Authentication flow changes:

* The `/login` route now accepts an optional `prompt` query parameter (defaulting to `"login"`) and passes it to the Azure AD login endpoint, allowing the application to force a fresh authentication when needed.
* The `/logout` route has been updated to redirect users back to the login screen with `prompt=login` after logging out, ensuring users are always prompted to re-authenticate after logging out.